### PR TITLE
Change view upon log in

### DIFF
--- a/src/app/add-recipe/add-recipe.component.html
+++ b/src/app/add-recipe/add-recipe.component.html
@@ -34,7 +34,7 @@
             </button> <!--(click)="backToView()" We need to fix routing after submit to go to View All-->
             <img *ngIf="loading"
                  src="data:image/gif;base64,R0lGODlhEAAQAPIAAP///wAAAMLCwkJCQgAAAGJiYoKCgpKSkiH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAEAAQAAADMwi63P4wyklrE2MIOggZnAdOmGYJRbExwroUmcG2LmDEwnHQLVsYOd2mBzkYDAdKa+dIAAAh+QQJCgAAACwAAAAAEAAQAAADNAi63P5OjCEgG4QMu7DmikRxQlFUYDEZIGBMRVsaqHwctXXf7WEYB4Ag1xjihkMZsiUkKhIAIfkECQoAAAAsAAAAABAAEAAAAzYIujIjK8pByJDMlFYvBoVjHA70GU7xSUJhmKtwHPAKzLO9HMaoKwJZ7Rf8AYPDDzKpZBqfvwQAIfkECQoAAAAsAAAAABAAEAAAAzMIumIlK8oyhpHsnFZfhYumCYUhDAQxRIdhHBGqRoKw0R8DYlJd8z0fMDgsGo/IpHI5TAAAIfkECQoAAAAsAAAAABAAEAAAAzIIunInK0rnZBTwGPNMgQwmdsNgXGJUlIWEuR5oWUIpz8pAEAMe6TwfwyYsGo/IpFKSAAAh+QQJCgAAACwAAAAAEAAQAAADMwi6IMKQORfjdOe82p4wGccc4CEuQradylesojEMBgsUc2G7sDX3lQGBMLAJibufbSlKAAAh+QQJCgAAACwAAAAAEAAQAAADMgi63P7wCRHZnFVdmgHu2nFwlWCI3WGc3TSWhUFGxTAUkGCbtgENBMJAEJsxgMLWzpEAACH5BAkKAAAALAAAAAAQABAAAAMyCLrc/jDKSatlQtScKdceCAjDII7HcQ4EMTCpyrCuUBjCYRgHVtqlAiB1YhiCnlsRkAAAOwAAAAAAAAAAAA==" />
-            <a [routerLink]="['/view']" class="btn-link ">Cancel</a> <!--TODO: Fix this with flexbox to look nicer-->
+            <a [routerLink]="['/recipe-list']" class="btn-link ">Cancel</a> <!--TODO: Fix this with flexbox to look nicer-->
           </div>
         </form>
       </div>

--- a/src/app/add-recipe/add-recipe.component.ts
+++ b/src/app/add-recipe/add-recipe.component.ts
@@ -70,7 +70,7 @@ export class AddRecipeComponent implements OnInit {
   }
 
   backToView(): void {
-    this.router.navigate(['/view']);
+    this.router.navigate(['/recipe-list']);
   }
 
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,11 +16,10 @@ const routes: Routes = [
   { path: 'login',          component: LoginComponent },
   { path: 'register',       component: RegisterComponent },
   { path: 'new',            component: AddRecipeComponent },
-  { path: 'view',           component: RecipeListComponent },
+  { path: 'recipe-list',           component: RecipeListComponent },
   { path: 'updateRecipe',   component: UpdateRecipeComponent },
   {
-    path: 'profile',
-    component: ProfileComponent,
+    path: 'profile',      component: ProfileComponent,
     canActivate: [AuthGuard],
   },
   {path: '**', redirectTo: '' }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -24,12 +24,12 @@ export class LoginComponent implements OnInit {
   ) {
     if (this.authService.isLoggedIn()) {
       window.alert("Already Logged in!");
-      this.router.navigate(["/profile"]);
+      this.router.navigate(["/recipe-list"]);
     }
   }
 
   ngOnInit() {
-    this.returnUrl = this.route.snapshot.queryParams.returnUrl || "/profile";
+    this.returnUrl = this.route.snapshot.queryParams.returnUrl || "/recipe-list";
   }
 
   login(loginForm: FormGroup) {


### PR DESCRIPTION
Two fairly minor changes to pathways:
1. When you log in it was going straight to the profile page to update user information. I changed it so when you log-in you go straight to the recipe list that shows the recipes you have entered.
2. When you click the add new recipe button, the new recipe container had a cancel button that used to go to a blank screen that only showed logout button. I changed this so that it goes back to the recipe list.